### PR TITLE
Add sql insert statement output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
-## Version 0.3.0
+## Version 0.4.0
+* Added #build_sql feature for generating the SQL statements for importing data from production into a development db.
 
-Now supports "where" conditions in the model spec. See production_sampler_spec.rb for implementation details.
+## Version 0.3.0
+* Add support for "where" conditions in the model spec. See production_sampler_spec.rb for implementation details.

--- a/lib/production_sampler.rb
+++ b/lib/production_sampler.rb
@@ -28,6 +28,12 @@ module ProductionSampler
       return extract_model(model_spec)
     end
 
+    def build_sql(model_spec)
+      hashie = build_hashie(model_spec)
+
+
+    end
+
     private
 
     def apply_filters_to_model(model_spec)
@@ -70,11 +76,7 @@ module ProductionSampler
         preload_model(model_spec, 'id', model_spec[:ids])
       end
 
-      # Apply any filters to the model; scope, where expressions, etc.
-      # klass_with_filters = apply_filters_to_model(model_spec)
-
       # Use the list of ID numbers to grab the preloaded ActiveRecord models for processing into a returned Hashie
-      #model_objects = klass_with_filters.where(id: model_spec[:ids])
       model_objects = find_preloaded_records_by_ids(model_spec[:base_model], model_spec[:ids])
       model_objects.each do |obj|
         model_data = filtered_attributes(obj, model_spec)

--- a/lib/production_sampler.rb
+++ b/lib/production_sampler.rb
@@ -148,19 +148,19 @@ module ProductionSampler
     # Takes an array of values, converts each one to a SQL-friendly text string
     def sql_safe(values)
       values.map do |val|
-        case val.class.to_s # I convert to string because for some reason if val.class is Fixnum, val.class === Fixnum == false
-          when "String", "ActiveSupport::TimeWithZone", "Date"
+        case val
+          when String, ActiveSupport::TimeWithZone, Date
             "'#{val}'"
-          when "Fixnum", "BigDecimal", "Float"
+          when Fixnum, BigDecimal, Float
             "#{val}"
-          when "FalseClass"
+          when FalseClass
             "false"
-          when "TrueClass"
+          when TrueClass
             "true"
-          when "NilClass"
+          when NilClass
             "null"
           else
-            raise Exception.new("Unknown SQL Type: #{val.class}")
+            raise ProductionSamplerError, "Unknown SQL Type: #{val.class}"
         end
       end
     end

--- a/lib/production_sampler/production_sampler_error.rb
+++ b/lib/production_sampler/production_sampler_error.rb
@@ -1,5 +1,4 @@
 module ProductionSampler
-
   class ProductionSamplerError < Exception
   end
 end

--- a/lib/production_sampler/version.rb
+++ b/lib/production_sampler/version.rb
@@ -1,3 +1,3 @@
 module ProductionSampler
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/spec/production_sampler_spec.rb
+++ b/spec/production_sampler_spec.rb
@@ -143,9 +143,9 @@ describe ProductionSampler do
       let(:expected_output) do
         <<-SQL
 INSERT INTO series (id,name) VALUES (1,'Star Trek TOS');
-INSERT INTO episodes (id,title,cost_cents) VALUES (1,'The Squire of Gothos',1995)
-INSERT INTO characters (id,names) VALUES (1,'Trelane')
-INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null)
+INSERT INTO episodes (id,title,cost_cents) VALUES (1,'The Squire of Gothos',1995);
+INSERT INTO characters (id,name) VALUES (1,'Trelane');
+INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
         SQL
       end
 

--- a/spec/production_sampler_spec.rb
+++ b/spec/production_sampler_spec.rb
@@ -115,6 +115,48 @@ describe ProductionSampler do
 
   end
 
+  describe "#build_sql" do
+    context "with a scope and a where condition" do
+      let(:model_spec) do
+        Hashie::Mash.new(
+          {
+            base_model: Series,
+            ids: [1],
+            columns: [:id, :name],
+            associations: [
+              {
+                association_name: 'episodes',
+                scope: 'season_one',
+                where: { expression: 'title NOT IN (?)', parameters: [["Return of the Archons", "Space Seed"]] }, # parameters must be an Array
+                columns: [:title, :cost_cents],
+                associations: [
+                  {
+                    association_name: 'characters',
+                    columns: [:name],
+                  }
+                ]
+              },
+            ]
+          })
+      end
+
+      let(:expected_output) do
+        <<-SQL
+INSERT INTO series (id,name) VALUES (1,'Star Trek TOS');
+INSERT INTO episodes (id,title,cost_cents) VALUES (1,'The Squire of Gothos',1995)
+INSERT INTO characters (id,names) VALUES (1,'Trelane')
+INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null)
+        SQL
+      end
+
+      it 'extracts the expected models and data' do
+        result = ps.build_sql(model_spec)
+        expect(result).to eql(expected_output)
+      end
+    end
+
+  end
+
   private
 
   def array_includes_expected(expectation, arr)


### PR DESCRIPTION
@MissingHandle @bintlopez @robb-broome @cngraf @dvanderbeek @ferdy89

Enhancements to the Production Sampler gem. It could be used to pull data from a production environment as SQL INSERT statements that could be used to load the data into another DB, such as a development or test environment. I'm using it to better replicate the bug that I am currently working to fix, since it could not be replicated in a simple test.

If you're unfamiliar, Production Sampler is currently used in the credit line interactor system as a means of pulling all required data about the credit line into an in-memory data source. This is a much more efficient approach than relying on the ActiveRecord models, which would query the database many times for a single business logic transaction.

I'd like to do some major refactoring of Production Sampler. All of the code resides in a single file. The concerns should actually be separated into modules. But I'll worry about that later as I am trying to fry bigger fish for now.