### PR TITLE
Support foreign keys that match to a different primary key on base model

### DIFF
--- a/spec/dummy/app/models/episode.rb
+++ b/spec/dummy/app/models/episode.rb
@@ -3,6 +3,7 @@ require 'money-rails'
 class Episode < ActiveRecord::Base
   belongs_to :series
   has_many :characters
+  has_many :ships, foreign_key: :episode_uuid, primary_key: :uuid
 
   monetize :cost_cents, allow_nil: true
 

--- a/spec/dummy/app/models/ship.rb
+++ b/spec/dummy/app/models/ship.rb
@@ -1,0 +1,3 @@
+class Ship < ActiveRecord::Base
+  belongs_to :episode, foreign_key: :episode_uuid, primary_key: :uuid
+end

--- a/spec/dummy/db/migrate/20160211210218_create_ships.rb
+++ b/spec/dummy/db/migrate/20160211210218_create_ships.rb
@@ -1,0 +1,11 @@
+class CreateShips < ActiveRecord::Migration
+  def change
+    create_table :ships do |t|
+      t.string :name
+      t.string :registry_number
+      t.string :episode_uuid
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20160211210557_add_uuid_to_episode.rb
+++ b/spec/dummy/db/migrate/20160211210557_add_uuid_to_episode.rb
@@ -1,0 +1,5 @@
+class AddUuidToEpisode < ActiveRecord::Migration
+  def change
+    add_column :episodes, :uuid, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151027203833) do
+ActiveRecord::Schema.define(version: 20160211210557) do
 
   create_table "characters", force: :cascade do |t|
     t.string   "name"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20151027203833) do
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
     t.integer  "cost_cents"
+    t.string   "uuid"
   end
 
   create_table "series", force: :cascade do |t|
@@ -35,6 +36,14 @@ ActiveRecord::Schema.define(version: 20151027203833) do
     t.string   "year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "ships", force: :cascade do |t|
+    t.string   "name"
+    t.string   "registry_number"
+    t.string   "episode_uuid"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
 
   create_table "species", force: :cascade do |t|

--- a/spec/production_sampler_spec.rb
+++ b/spec/production_sampler_spec.rb
@@ -45,12 +45,16 @@ describe ProductionSampler do
               {
                 association_name: 'episodes',
                 scope: 'season_one',
-                where: { expression: 'title NOT IN (?)', parameters: [["Return of the Archons", "Space Seed"]] }, # parameters must be an Array
-                columns: [:title, :cost],
+                where: { expression: 'title NOT IN (?)', parameters: [["Return of the Archons", "Arena"]] }, # parameters must be an Array
+                columns: [:title, :cost, :uuid],
                 associations: [
                   {
                     association_name: 'characters',
                     columns: [:name],
+                  },
+                  {
+                    association_name: 'ships',
+                    columns: [:name, :registry_number]
                   }
                 ]
               },
@@ -69,18 +73,28 @@ describe ProductionSampler do
                   id: 1,
                   title: "The Squire of Gothos",
                   cost: Money.new(1995),
+                  uuid: '5922d60a-b05b-4157-b5ee-41ffa6379796',
                   characters: [
                     {
                       id: 1,
                       name: "Trelane"
                     },
-                  ]
+                  ],
+                  ships: []
                 },
                 {
-                  id: 2,
-                  title: "Arena",
+                  id: 4,
+                  title: "Space Seed",
                   cost: nil,
+                  uuid: '94544426-7b53-450c-9f03-42a3a48ad21d',
                   characters: [],
+                  ships: [
+                    {
+                      id: 1,
+                      name: 'SS Botany Bay',
+                      registry_number: nil
+                    }
+                  ]
                 }
               ]
             }
@@ -178,6 +192,7 @@ INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
 
     Episode.create(
       id: 1,
+      uuid: '5922d60a-b05b-4157-b5ee-41ffa6379796',
       title: "The Squire of Gothos",
       production_number: "1x17",
       series_id: 1,
@@ -186,6 +201,7 @@ INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
 
     Episode.create(
       id: 2,
+      uuid: 'ce62f25d-8de1-437f-a2fe-7b500c7e5caa',
       title: "Arena",
       production_number: "1x18",
       series_id: 1
@@ -193,6 +209,7 @@ INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
 
     Episode.create(
       id: 3,
+      uuid: 'd5df36d7-56e9-4e77-9397-233e3bdd57dd',
       title: "Return of the Archons",
       production_number: "1x21",
       series_id: 1
@@ -200,6 +217,7 @@ INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
 
     Episode.create(
       id: 4,
+      uuid: '94544426-7b53-450c-9f03-42a3a48ad21d',
       title: "Space Seed",
       production_number: "1x22",
       series_id: 1
@@ -207,6 +225,7 @@ INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
 
     Episode.create(
       id: 5,
+      uuid: '0ceb99ff-c35c-4d18-abde-5b35aeff8f95',
       title: "Amok Time",
       production_number: "2x30",
       series_id: 1
@@ -214,6 +233,7 @@ INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
 
     Episode.create(
       id: 6,
+      uuid: '9f148d8e-8520-43b5-a5e5-512aa3a4e2d6',
       title: "Who Mourns for Adonias?",
       production_number: "2x31",
       series_id: 1
@@ -221,6 +241,7 @@ INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
 
     Episode.create(
       id: 7,
+      uuid: 'f0fb4f0c-8cdd-4cd1-b43f-00fe9de4485c',
       title: "Encounter at Farpoint",
       production_number: "1x1",
       series_id: 2
@@ -248,6 +269,12 @@ INSERT INTO episodes (id,title,cost_cents) VALUES (2,'Arena',null);
       name: "Q",
       species_id: 2,
       episode_id: 3
+    )
+
+    Ship.create(
+      id: 1,
+      name: 'SS Botany Bay',
+      episode_uuid: '94544426-7b53-450c-9f03-42a3a48ad21d'
     )
   end
 


### PR DESCRIPTION
@MissingHandle @robb-broome @cngraf @dvanderbeek @bintlopez

This PR adds support for associations with a different primary key on the base model. For example, in avant-basic I can't extract Loan->Payment Plans because the payment_plans table's relationship maps to Loan.uuid instead of Loan.id. This fixes the problem so I can do a has_many relationship over a different key.