### PR TITLE
Remove nil class names before sorting

### DIFF
--- a/lib/production_sampler/production_sampler.rb
+++ b/lib/production_sampler/production_sampler.rb
@@ -17,7 +17,7 @@ module ProductionSampler
         # load only the specified models
         load_models.each { |m| load_model(m) }
       end
-      @app_models = ActiveRecord::Base.descendants.map { |d| d.name }.sort
+      @app_models = ActiveRecord::Base.descendants.compact.map { |d| d.name }.sort
     end
 
     def build_hashie(model_spec)


### PR DESCRIPTION
Some test suites define anonymous classes which inherit from ActiveRecord::Base. This ensures those classes name method, which responds as nil, are removed before sorting is attempted. Without this, an error is raised due to comparing some string with nil.